### PR TITLE
Fix CI

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -11,4 +11,4 @@ RestartSec=2s
 Restart=always
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -5,8 +5,8 @@ Description=Rclone: WebGUI
 Type=simple
 User=__APP__
 Group=__APP__
-#WorkingDirectory=~
-ExecStart=__INSTALL_DIR__/rclone rcd --rc-web-gui --rc-addr 127.0.0.1:__PORT__ --rc-user __ADMIN__ --rc-pass __PASSWORD__ --rc-web-gui-update --rc-web-gui-no-open-browser
+WorkingDirectory=__INSTALL_DIR__/
+ExecStart=-__INSTALL_DIR__/rclone rcd --rc-web-gui --rc-addr 127.0.0.1:__PORT__ --rc-user __ADMIN__ --rc-pass __PASSWORD__ --rc-web-gui-update --rc-web-gui-no-open-browser
 
 [Install]
 WantedBy=default.target

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -6,7 +6,9 @@ Type=simple
 User=__APP__
 Group=__APP__
 WorkingDirectory=__INSTALL_DIR__/
-ExecStart=/bin/sh -c "__INSTALL_DIR__/rclone rcd --rc-web-gui --rc-addr 127.0.0.1:__PORT__ --rc-user __ADMIN__ --rc-pass __PASSWORD__ --rc-web-gui-update --rc-web-gui-no-open-browser; exit 0;"
+ExecStart=__INSTALL_DIR__/rclone rcd --rc-web-gui --rc-addr 127.0.0.1:__PORT__ --rc-user __ADMIN__ --rc-pass __PASSWORD__ --rc-web-gui-update --rc-web-gui-no-open-browser
+RestartSec=2s
+Restart=always
 
 [Install]
 WantedBy=default.target

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -6,7 +6,7 @@ Type=simple
 User=__APP__
 Group=__APP__
 WorkingDirectory=__INSTALL_DIR__/
-ExecStart=-__INSTALL_DIR__/rclone rcd --rc-web-gui --rc-addr 127.0.0.1:__PORT__ --rc-user __ADMIN__ --rc-pass __PASSWORD__ --rc-web-gui-update --rc-web-gui-no-open-browser
+ExecStart=/bin/sh -c "__INSTALL_DIR__/rclone rcd --rc-web-gui --rc-addr 127.0.0.1:__PORT__ --rc-user __ADMIN__ --rc-pass __PASSWORD__ --rc-web-gui-update --rc-web-gui-no-open-browser; exit 0;"
 
 [Install]
 WantedBy=default.target

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -5,7 +5,7 @@ Description=Rclone: WebGUI
 Type=simple
 User=__APP__
 Group=__APP__
-WorkingDirectory=~
+#WorkingDirectory=~
 ExecStart=__INSTALL_DIR__/rclone rcd --rc-web-gui --rc-addr 127.0.0.1:__PORT__ --rc-user __ADMIN__ --rc-pass __PASSWORD__ --rc-web-gui-update --rc-web-gui-no-open-browser
 
 [Install]

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -5,8 +5,8 @@ Description=Rclone: WebGUI
 Type=simple
 User=__APP__
 Group=__APP__
-WorkingDirectory=__INSTALL_DIR__/
-ExecStart=__INSTALL_DIR__/rclone rcd --rc-web-gui --rc-web-gui-update --rc-addr 127.0.0.1:__PORT__ --rc-user __ADMIN__ --rc-pass __PASSWORD__ --rc-web-gui-no-open-browser
+WorkingDirectory=~
+ExecStart=__INSTALL_DIR__/rclone rcd --rc-web-gui --rc-addr 127.0.0.1:__PORT__ --rc-user __ADMIN__ --rc-pass __PASSWORD__ --rc-web-gui-update --rc-web-gui-no-open-browser
 
 [Install]
 WantedBy=default.target

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -6,7 +6,7 @@ Type=simple
 User=__APP__
 Group=__APP__
 WorkingDirectory=__INSTALL_DIR__/
-ExecStart=__INSTALL_DIR__/rclone rcd --rc-web-gui --rc-addr 127.0.0.1:__PORT__ --rc-user __ADMIN__ --rc-pass __PASSWORD__ --rc-web-gui-update
+ExecStart=__INSTALL_DIR__/rclone rcd --rc-web-gui --rc-web-gui-update --rc-addr 127.0.0.1:__PORT__ --rc-user __ADMIN__ --rc-pass __PASSWORD__ --rc-web-gui-no-open-browser
 
 [Install]
 WantedBy=default.target

--- a/scripts/install
+++ b/scripts/install
@@ -8,6 +8,13 @@ source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
+# STORE SETTINGS FROM MANIFEST
+#=================================================
+
+# Not saved by default
+ynh_app_setting_set --app=$app --key=password --value="$password"
+
+#=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
 ynh_script_progression --message="Setting up source files..." --weight=1

--- a/tests.toml
+++ b/tests.toml
@@ -76,3 +76,6 @@ test_format = 1.0
 
     # args.language = "en_GB"
     # args.multisite = 1
+
+    [default.curl_tests]
+    default.expect_return_code= 401


### PR DESCRIPTION
## Problem

1. <del>Tag file reading error `ERROR : Error reading tag file at /var/www/rclone/.cache/rclone/webgui/tag`</del>
2. Don't start browser server-side `ERROR : Failed to open Web GUI in browser: exec: "xdg-open": executable file not found in $PATH. Manually access it at: http://package_checker:MySuperComplexPassword@127.0.0.1:5572/?login_token=cGFja2FnZV9jaGVja2VyOk15U3VwZXJDb21wbGV4UGFzc3dvcmQ%3D`
3. HTTP 502 Bad Gateway error in tests (because systemd unit was stopped)

## Solution

1. <del>Change systemd's working directory to user's home folder</del>
2. Add `--rc-web-gui-no-open-browser` flag
3. Change systemd's WantedBy target from `default.target` to `multi-user.target`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
