### PR TITLE
removes the basic auth pop up, and shows the rclone web gui login

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -6,7 +6,7 @@ Type=simple
 User=__APP__
 Group=__APP__
 WorkingDirectory=__INSTALL_DIR__/
-ExecStart=__INSTALL_DIR__/rclone rcd --rc-web-gui --rc-addr 127.0.0.1:__PORT__ --rc-user "__ADMIN__" --rc-pass "__PASSWORD__" --rc-web-gui-update --rc-web-gui-no-open-browser
+ExecStart=__INSTALL_DIR__/rclone rcd --rc-web-gui --rc-addr 127.0.0.1:__PORT__ --rc-no-auth --rc-web-gui-update --rc-web-gui-no-open-browser
 RestartSec=2s
 Restart=always
 


### PR DESCRIPTION
https://forum.yunohost.org/t/rclone-http-auth-not-accepting-password/35177/14

## Problem

- basic auth pop up

## Solution

- "--rc-no-auth"

## PR Status

- [ ] Code finished and ready to be reviewed/tested
